### PR TITLE
refactor: instantiate settings, improve logging

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_module}}/resources.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_module}}/resources.py
@@ -15,15 +15,13 @@
 
 """Implement RESTful API endpoints using resources."""
 
-import logging
-
 from flask_restplus import Resource
 
-
-LOGGER = logging.getLogger(__name__)
+from {{cookiecutter.project_module}}.app import app
 
 
 class HelloWorld(Resource):
     def get(self):
         """Shout out loud."""
+        app.logger.debug("I ran!")
         return "Hello World!"

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_module}}/settings.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_module}}/settings.py
@@ -21,12 +21,14 @@ import os
 __all__ = ("Development", "Testing", "Production")
 
 
-class Default:
+class Default(object):
 
-    DEBUG = True
-    SECRET_KEY = os.urandom(24)
-    LOGLEVEL = "DEBUG"
-    CORS_ORIGINS = os.environ['ALLOWED_ORIGINS'].split(",")
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.DEBUG = True
+        self.SECRET_KEY = os.urandom(24)
+        self.LOGLEVEL = "DEBUG"
+        self.CORS_ORIGINS = os.environ['ALLOWED_ORIGINS'].split(",")
 
 
 class Development(Default):
@@ -39,6 +41,8 @@ class Testing(Default):
 
 class Production(Default):
 
-    DEBUG = False
-    SECRET_KEY = os.environ.get('SECRET_KEY')
-    LOGLEVEL = "INFO"
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.DEBUG = False
+        self.SECRET_KEY = os.environ['SECRET_KEY']
+        self.LOGLEVEL = "INFO"


### PR DESCRIPTION
* Use instances for configuration such that there are no `KeyError`s
  with environment variables on import.
* Move import into `init_app` to avoid circular imports.
* Fix the logging situation.