### PR TITLE
Ignore errors in make qa targets

### DIFF
--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -17,15 +17,15 @@ qa: test flake8 isort license
 
 ## Run the tests
 test:
-	docker-compose run --rm -e ENVIRONMENT=testing web pytest --cov={{cookiecutter.project_module}} tests
+	-docker-compose run --rm -e ENVIRONMENT=testing web pytest --cov={{cookiecutter.project_module}} tests
 
 ## Run flake8
 flake8:
-	docker-compose run --rm web flake8 {{cookiecutter.project_module}} tests
+	-docker-compose run --rm web flake8 {{cookiecutter.project_module}} tests
 
 ## Check import sorting
 isort:
-	docker-compose run --rm web isort --check-only --recursive {{cookiecutter.project_module}} tests
+	-docker-compose run --rm web isort --check-only --recursive {{cookiecutter.project_module}} tests
 
 ## Sort imports and write changes to files
 isort-save:
@@ -33,7 +33,7 @@ isort-save:
 
 ## Verify source code license headers
 license:
-	./scripts/verify_license_headers.sh {{cookiecutter.project_module}}
+	-./scripts/verify_license_headers.sh {{cookiecutter.project_module}}
 
 ## Shut down the Docker containers.
 stop:


### PR DESCRIPTION
Reasoning: A user running `make qa` most likely wants feedback about all QA targets, not only the first to fail.