### PR TITLE
Logging

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_module}}/app.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_module}}/app.py
@@ -42,18 +42,12 @@ def init_app(application, interface):
         from {{cookiecutter.project_module}}.settings import Development
         application.config.from_object(Development())
 
-    # Configure the logger and handler.
-    application.logger.setLevel(application.config["LOGLEVEL"])
-    formatter = logging.Formatter("[%(levelname)s] [%(name)s] %(message)s")
-    for handler in application.logger.handlers:
-        handler.setFormatter(formatter)
-
-    # Set the logging level and add handlers to desired packages here.
-    # FIXME: Remove those that are too spammy and uninteresting.
-    cors_logger = logging.getLogger("flask_cors")
-    cors_logger.setLevel(application.config["LOGLEVEL"])
-    for handler in application.logger.handlers:
-        cors_logger.addHandler(handler)
+    # Configure logging
+    # The flask logger, when created, disables existing loggers. The following
+    # statement ensures the flask logger is created, so that it doesn't disable
+    # our loggers later when it is first accessed.
+    application.logger
+    logging.config.dictConfig(application.config['LOGGING'])
 
     # Add routes and resources.
     from {{cookiecutter.project_module}} import resources

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_module}}/settings.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_module}}/settings.py
@@ -33,7 +33,8 @@ class Default(object):
             'disable_existing_loggers': False,
             'formatters': {
                 'simple': {
-                    'format': "[%(levelname)s] [%(name)s] %(message)s",
+                    'format': "%(asctime)s [%(levelname)s] [%(name)s] "
+                              "%(message)s",
                 },
             },
             'handlers': {

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_module}}/settings.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_module}}/settings.py
@@ -27,8 +27,32 @@ class Default(object):
         super().__init__(**kwargs)
         self.DEBUG = True
         self.SECRET_KEY = os.urandom(24)
-        self.LOGLEVEL = "DEBUG"
         self.CORS_ORIGINS = os.environ['ALLOWED_ORIGINS'].split(",")
+        self.LOGGING = {
+            'version': 1,
+            'disable_existing_loggers': False,
+            'formatters': {
+                'simple': {
+                    'format': "[%(levelname)s] [%(name)s] %(message)s",
+                },
+            },
+            'handlers': {
+                'console': {
+                    'level': 'DEBUG',
+                    'class': 'logging.StreamHandler',
+                    'formatter': 'simple',
+                },
+            },
+            'loggers': {
+                # All loggers will by default use the root logger below (and
+                # hence be very verbose). To silence spammy/uninteresting log
+                # output, add the loggers here and increase the loglevel.
+            },
+            'root': {
+                'level': 'DEBUG',
+                'handlers': ['console'],
+            },
+        }
 
 
 class Development(Default):
@@ -45,4 +69,4 @@ class Production(Default):
         super().__init__(**kwargs)
         self.DEBUG = False
         self.SECRET_KEY = os.environ['SECRET_KEY']
-        self.LOGLEVEL = "INFO"
+        self.LOGGING['root']['level'] = 'INFO'


### PR DESCRIPTION
- Configure logging as a dict in `settings.py`. This is a bit verbose, but arguably makes the configuration more readable and easier to update.
- Now only the root logger is configured, which outputs all logs to console, with the possibility to define spammy loggers under the `loggers` dict with a higher level filter.
- Adjusted the default format to include timestamp
- Sends production logs to logstash. The format will need to be configured in logstash before this will work though