### PR TITLE
Display API docs on root url

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_module}}/app.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_module}}/app.py
@@ -28,7 +28,6 @@ api = Api(
     title="{{cookiecutter.project_name}} API",
     version="0.1.0",
     description="{{cookiecutter.project_short_description}}",
-    doc="/docs"  # FIXME: Should be disabled in production.
 )
 
 


### PR DESCRIPTION
Isn't it a nice convenience to use the built-in swagger display? If you agree it could be available then I suggest to just show it at the root URL, so that in the future when we namespace each service consistently under one path, their docs will be available there as well as in the collected docs.