### PR TITLE
Hide field mask header from swagger docs

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_module}}/settings.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_module}}/settings.py
@@ -29,6 +29,7 @@ class Default(object):
         self.SECRET_KEY = os.urandom(24)
         self.LOGLEVEL = "DEBUG"
         self.CORS_ORIGINS = os.environ['ALLOWED_ORIGINS'].split(",")
+        self.RESTPLUS_MASK_SWAGGER = False
 
 
 class Development(Default):


### PR DESCRIPTION
This is a global header, and if used ubiquitously, does not need to be included in each endpoint's API docs.