### PR TITLE
Add `setup` make target

### DIFF
--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -1,10 +1,13 @@
-.PHONY: network build start qa style test test-travis flake8 isort isort-save \
-		license stop clean logs
+.PHONY: setup network build start qa style test test-travis flake8 isort \
+		isort-save license stop clean logs
 SHELL:=/bin/bash
 
 #################################################################################
 # COMMANDS                                                                      #
 #################################################################################
+
+## Run all initialization targets.
+setup: build
 
 ## Create the docker bridge network if necessary.
 network:

--- a/{{cookiecutter.project_slug}}/README.md
+++ b/{{cookiecutter.project_slug}}/README.md
@@ -25,7 +25,8 @@ Perform the following steps after creating a new service from the cookiecutter.
 
 ## Development
 
-Type `make` to see all commands.
+Run `make setup` first when initializing the project for the first time. Type
+`make` to see all commands.
 
 ### Environment
 


### PR DESCRIPTION
Suggest this as a standardized way to run all commands that must be executed before starting the services - e.g. creating databases, installing fixtures, etc.