### PR TITLE
Pipenv

### DIFF
--- a/{{cookiecutter.project_slug}}/.travis.yml
+++ b/{{cookiecutter.project_slug}}/.travis.yml
@@ -37,7 +37,7 @@ jobs:
   include:
     - stage: build
       script:
-        - make build
+        - make build-travis
         - docker push {{cookiecutter.docker_organization}}/{{cookiecutter.project_slug}}:${IMAGE_TAG}
     - stage: deploy
       script:

--- a/{{cookiecutter.project_slug}}/Dockerfile
+++ b/{{cookiecutter.project_slug}}/Dockerfile
@@ -11,6 +11,8 @@ ARG CWD=/app
 
 ENV PYTHONPATH=${CWD}/src
 
+ARG PIPENV_CMD="pipenv install --dev --system"
+
 RUN addgroup -g "${GID}" -S "${APP_USER}" && \
     adduser -u "${UID}" -G "${APP_USER}" -S "${APP_USER}"
 
@@ -28,7 +30,7 @@ RUN set -x \
     && ln -sf /usr/local/bin/python /bin/python \
     && apk add --no-cache --virtual .build-deps g++ \
     && pip install --upgrade pip setuptools wheel pipenv \
-    && pipenv install --dev --system --deploy \
+    && ${PIPENV_CMD} \
     && rm -rf /root/.cache/pip \
     && apk del .build-deps
 

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -17,6 +17,7 @@ network:
 ## Build local docker images.
 build: network
 	docker-compose build
+	./scripts/copy_pipenv_lockfile.sh
 
 ## Build local docker images for deployment.
 build-travis:

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -18,6 +18,10 @@ network:
 build: network
 	docker-compose build
 
+## Build local docker images for deployment.
+build-travis:
+	docker-compose build --build-arg PIPENV_CMD="pipenv install --dev --system --deploy"
+
 ## Start all services in the background.
 start:
 	docker-compose up -d

--- a/{{cookiecutter.project_slug}}/scripts/copy_pipenv_lockfile.sh
+++ b/{{cookiecutter.project_slug}}/scripts/copy_pipenv_lockfile.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Copyright (c) {{cookiecutter.year}}, Novo Nordisk Foundation Center for Biosustainability,
+# Technical University of Denmark.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+CONTAINER=$(docker create {{cookiecutter.docker_organization}}/{{cookiecutter.project_slug}}:${IMAGE_TAG:-latest})
+docker cp "${CONTAINER}:/app/Pipfile.lock" .
+docker rm ${CONTAINER}
+echo "Copied generated Pipfile.lock to your current workdir"


### PR DESCRIPTION
The "heisenbug" was caused by make, which expands all lines of a recipe before actually running them, i.e. creating a container out of the image before the recipe runs and builds it. On subsequent builds, the image would already exist, so the error was not apparent.

I found it easier to solve this with a shell script, rather than reading up on the Makefile syntax.