### PR TITLE
Do not require build for setup target

### DIFF
--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -7,7 +7,7 @@ SHELL:=/bin/bash
 #################################################################################
 
 ## Run all initialization targets.
-setup:
+setup: network
 
 ## Create the docker bridge network if necessary.
 network:
@@ -15,7 +15,7 @@ network:
 		docker network create {{cookiecutter.github_username}}
 
 ## Build local docker images.
-build: network
+build:
 	docker-compose build
 	./scripts/copy_pipenv_lockfile.sh
 

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -7,7 +7,7 @@ SHELL:=/bin/bash
 #################################################################################
 
 ## Run all initialization targets.
-setup: build
+setup:
 
 ## Create the docker bridge network if necessary.
 network:


### PR DESCRIPTION
It should be possible to pull images and run setup without requiring a rebuild (e.g. for the CI jobs in test stage).