### PR TITLE
Don't copy source code after build

### DIFF
--- a/{{cookiecutter.project_slug}}/Dockerfile
+++ b/{{cookiecutter.project_slug}}/Dockerfile
@@ -20,7 +20,7 @@ RUN apk add --update --no-cache openssl ca-certificates
 
 WORKDIR "${CWD}"
 
-COPY Pipfile* "${CWD}/"
+COPY . "${CWD}/"
 
 # `g++` is required for building `gevent` but all build dependencies are
 # later removed again to reduce the layer size.
@@ -33,7 +33,5 @@ RUN set -x \
     && pipenv install --system ${PIPENV_FLAGS} \
     && rm -rf /root/.cache/pip \
     && apk del .build-deps
-
-COPY . "${CWD}/"
 
 RUN chown -R "${APP_USER}:${APP_USER}" "${CWD}"


### PR DESCRIPTION
Unfortunately, this optimization has the side effect of overwriting the generated Pipfile.lock when an older version already exists in the workdir, before it is copied out post-build.