### PR TITLE
Install packages system-wide

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
   - pip install -U pip setuptools wheel
   - pip install pipenv
 install:
-  - pipenv install --dev
+  - pipenv install --dev --system
 script: pytest
 notifications:
   on_success: never


### PR DESCRIPTION
Please note that this is for the actual *cookiecutter* CI, not the resulting template :)

Our builds suddenly all started to fail with pipenv v11.10.1 released a few hours ago and from what I can tell it seems to be related to `pipenv install` not working within virtualenvs anymore, so I've reported [an issue](https://github.com/pypa/pipenv/issues/2078) to see if it was unintended or not.

This change circumvents the problem by installing the test suite system-wide, combined with having added `PIPENV_IGNORE_VIRTUALENVS=1` to Travis env.

I also considered dropping pipenv entirely from the cookiecutters Travis build - I don't see what it adds, and this was certainly an unnecessary distraction.