### PR TITLE
refactor: no need to create the flask logger anymore

### DIFF
--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_module}}/app.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_module}}/app.py
@@ -46,10 +46,6 @@ def init_app(application, interface):
         application.config.from_object(Development())
 
     # Configure logging
-    # The flask logger, when created, disables existing loggers. The following
-    # statement ensures the flask logger is created, so that it doesn't disable
-    # our loggers later when it is first accessed.
-    application.logger
     logging.config.dictConfig(application.config['LOGGING'])
 
     # Configure Sentry


### PR DESCRIPTION
With the release of Flask 1.0 this is no longer necessary.