### PR TITLE
fix: add workaround for platform misdetection

### DIFF
--- a/{{cookiecutter.project_slug}}/Pipfile
+++ b/{{cookiecutter.project_slug}}/Pipfile
@@ -8,6 +8,7 @@ Flask = "*"
 Flask-Cors = "*"
 flask-restplus = "*"
 gunicorn = "*"
+greenlet = {version = "*", platform_python_implementation="=='CPython'"}
 gevent = "*"
 raven = {version = "*", extras = ["flask"]}
 


### PR DESCRIPTION
This is a (hopefully) temporary workaround for the platform not being properly detected by pipenv and thus `greenlet` not being installed which breaks gunicorn. See https://github.com/pypa/pipenv/issues/2113 for more details.

I'm not sure whether to merge this or wait this one out but it definitely annoyed me so if anyone is creating a service soon with this template, please be aware.