### PR TITLE
refactor: force creation of new containers

### DIFF
--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -24,7 +24,7 @@ build:
 
 ## Start all services in the background.
 start:
-	docker-compose up -d
+	docker-compose up --force-recreate -d
 
 ## Run all QA targets.
 qa: test pipenv-check style


### PR DESCRIPTION
Forcing the creation of new containers with every up will remove the old logs (they can become very long quickly with noisy webservices and gunicorn etc.). I don't see a downside to this at the moment.