### PR TITLE
refactor: bundle and return all request errors

### DIFF
--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_module}}/settings.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_module}}/settings.py
@@ -34,6 +34,7 @@ class Default:
         """
         self.DEBUG = True
         self.SECRET_KEY = os.urandom(24)
+        self.BUNDLE_ERRORS = True
         self.CORS_ORIGINS = os.environ['ALLOWED_ORIGINS'].split(",")
         self.SENTRY_DSN = os.environ.get('SENTRY_DSN')
         self.LOGGING = {


### PR DESCRIPTION
Normally the `RequestParser` will abort after hitting the first error. This way it will attempt to continue parsing the request and return all validation errors together. I consider this a benefit to clients developing against our APIs (and for ourselves of course :wink: ).