### PR TITLE
Ensure makefile exits non-0 on failure

### DIFF
--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -34,7 +34,7 @@ style: flake8 isort license
 
 ## Run the tests.
 test:
-	-docker-compose run --rm -e ENVIRONMENT=testing web \
+	docker-compose run --rm -e ENVIRONMENT=testing web \
 		/bin/sh -c "pytest -s --cov=src/{{cookiecutter.project_module}} tests"
 
 ## Run the tests and report coverage (see https://docs.codecov.io/docs/testing-with-docker).
@@ -45,16 +45,16 @@ test-travis:
 
 ## Check for known vulnerabilities in python dependencies.
 pipenv-check:
-	-docker-compose run --rm web pipenv check --system
+	docker-compose run --rm web pipenv check --system
 
 ## Run flake8.
 flake8:
-	-docker-compose run --rm web \
+	docker-compose run --rm web \
 		flake8 src/{{cookiecutter.project_module}} tests
 
 ## Check Python package import order.
 isort:
-	-docker-compose run --rm web \
+	docker-compose run --rm web \
 		isort --check-only --recursive src/{{cookiecutter.project_module}} tests
 
 ## Sort imports and write changes to files.
@@ -64,7 +64,7 @@ isort-save:
 
 ## Verify source code license headers.
 license:
-	-./scripts/verify_license_headers.sh src/{{cookiecutter.project_module}} tests
+	./scripts/verify_license_headers.sh src/{{cookiecutter.project_module}} tests
 
 ## Stop all services.
 stop:


### PR DESCRIPTION
This syntax does not work as intended and does exit 0 despite failures. I thought I tested this but obviously did not, sorry.

This means that CI scripts should run each target separately (and not run targets like `qa` or `style`) in order to provide feedback for all targets even if an early target fails.