### PR TITLE
Set image tag to branch name

### DIFF
--- a/{{cookiecutter.project_slug}}/.travis.yml
+++ b/{{cookiecutter.project_slug}}/.travis.yml
@@ -10,8 +10,7 @@ services:
 env:
   global:
     - IMAGE_REPO=gcr.io/{{cookiecutter.gcloud_project}}/{{cookiecutter.project_slug}}
-    - IMAGE_TAG=travis-ci-test
-    - IMAGE=${IMAGE_REPO}:${IMAGE_TAG}
+    - IMAGE_TAG=${TRAVIS_BRANCH}
 
 before_install:
   - echo ${DOCKER_PASSWORD} | docker login -u=decaftravis --password-stdin


### PR DESCRIPTION
This ensures that docker-compose commands (QA targets) will reuse the already-built image and not build a new one.