### PR TITLE
fix: upload codecov outside docker

### DIFF
--- a/{{cookiecutter.project_slug}}/.travis-covrc
+++ b/{{cookiecutter.project_slug}}/.travis-covrc
@@ -1,0 +1,4 @@
+[run]
+data_file = /tmp/coverage/.coverage
+source =
+    src/{{cookiecutter.project_module}}

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -58,13 +58,15 @@ pipenv-check:
 ## Run the tests.
 test:
 	docker-compose run --rm -e ENVIRONMENT=testing web \
-		/bin/sh -c "pytest -s --cov=src/{{cookiecutter.project_module}} tests"
+		/bin/sh -c "pytest -s --cov=src/{{cookiecutter.project_module}}"
 
 ## Run the tests and report coverage (see https://docs.codecov.io/docs/testing-with-docker).
+shared := /tmp/coverage
 test-travis:
-	$(eval ci_env=$(shell bash <(curl -s https://codecov.io/env)))
-	docker-compose run --rm -e ENVIRONMENT=testing $(ci_env)  web \
-		/bin/sh -c "pytest -s --cov=src/{{cookiecutter.project_module}} tests && codecov"
+	mkdir "$(shared)"
+	docker-compose run --rm -e ENVIRONMENT=testing -v "$(shared):$(shared)" \
+		web pytest -s --cov-config=.travis-covrc --cov
+	bash <(curl -s https://codecov.io/bash) -f "$(shared)/.coverage"
 
 ## Stop all services.
 stop:

--- a/{{cookiecutter.project_slug}}/Pipfile
+++ b/{{cookiecutter.project_slug}}/Pipfile
@@ -15,7 +15,6 @@ raven = {version = "*", extras = ["flask"]}
 [dev-packages]
 pytest = "*"
 pytest-cov = "*"
-codecov = "*"
 flake8 = "*"
 flake8-docstrings = "*"
 isort = "*"


### PR DESCRIPTION
* Create a configuration just for Travis.
* Map a volume inside docker to retrieve coverage.
* Upload the report outside docker to avoid git dependency.
* Test directories already defined in `setup.cfg` thus remove them.