### PR TITLE
Send warning and higher logs to Sentry

### DIFF
--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_module}}/settings.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_module}}/settings.py
@@ -65,6 +65,11 @@ class Default:
                     'formatter': 'simple',
                 },
             },
+            'sentry': {
+                'level': 'ERROR',
+                'class': 'raven.handlers.logging.SentryHandler',
+                'dsn': self.SENTRY_DSN,
+            },
             'loggers': {
                 # All loggers will by default use the root logger below (and
                 # hence be very verbose). To silence spammy/uninteresting log
@@ -72,7 +77,7 @@ class Default:
             },
             'root': {
                 'level': 'DEBUG',
-                'handlers': ['console'],
+                'handlers': ['console', 'sentry'],
             },
         }
 


### PR DESCRIPTION
Just realized this was not added here, but it is the current behaviour of most of the services.

The idea is that any log event with `WARNING` or higher level requires attention and therefore should be logged to Sentry (and send notification) to be looked at and resolved.

I'm a bit on the fence between having this on `WARNING` or on `ERROR` though.