### PR TITLE
Limit gunicorn logs to INFO

### DIFF
--- a/{{cookiecutter.project_slug}}/gunicorn.py
+++ b/{{cookiecutter.project_slug}}/gunicorn.py
@@ -23,17 +23,14 @@ bind = "0.0.0.0:8000"
 worker_class = "gevent"
 timeout = 20
 accesslog = "-"
+access_log_format = '''%(t)s "%(r)s" %(s)s %(b)s %(L)s "%(f)s"'''
 
 
 if _config == "production":
     workers = os.cpu_count() * 2 + 1
     preload_app = True
-    loglevel = "INFO"
-    access_log_format = '''"%(r)s" %(s)s %(b)s %(L)s "%(f)s"'''
 else:
     # FIXME: The number of workers is up for debate. At least for testing more
     # than one worker could make sense.
     workers = 1
     reload = True
-    loglevel = "DEBUG"
-    access_log_format = '''%(t)s "%(r)s" %(s)s %(b)s %(L)s "%(f)s"'''


### PR DESCRIPTION
After experimenting a bit with the loglevels, I now think the DEBUG output is a bit excessive, e.g., it prints all requests, which makes for a duplicate access log. This changes to use INFO (the default).

The access log format is also changed to include timestamp in production as we no longer get that by default from Docker Cloud.