### PR TITLE
Revert sentry

### DIFF
--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_module}}/app.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_module}}/app.py
@@ -43,7 +43,7 @@ def init_app(application, interface):
     # Configure Sentry
     if application.config['SENTRY_DSN']:
         sentry = Sentry(dsn=application.config['SENTRY_DSN'], logging=True,
-                        level=logging.WARNING)
+                        level=logging.ERROR)
         sentry.init_app(application)
 
     # Add routes and resources.

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_module}}/settings.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_module}}/settings.py
@@ -65,11 +65,6 @@ class Default:
                     'formatter': 'simple',
                 },
             },
-            'sentry': {
-                'level': 'ERROR',
-                'class': 'raven.handlers.logging.SentryHandler',
-                'dsn': self.SENTRY_DSN,
-            },
             'loggers': {
                 # All loggers will by default use the root logger below (and
                 # hence be very verbose). To silence spammy/uninteresting log
@@ -77,7 +72,7 @@ class Default:
             },
             'root': {
                 'level': 'DEBUG',
-                'handlers': ['console', 'sentry'],
+                'handlers': ['console'],
             },
         }
 


### PR DESCRIPTION
Logging is actually configured in the Sentry initializer now and not needed in the custom log configuration. Sorry for adding the unnecessary PR, but this at least updates the level to `ERROR`.