### PR TITLE
Monkeypatch gevent early

### DIFF
--- a/{{cookiecutter.project_slug}}/gunicorn.py
+++ b/{{cookiecutter.project_slug}}/gunicorn.py
@@ -17,6 +17,18 @@
 
 import os
 
+import gevent.monkey
+
+
+# Ensure gevent is monkeypatched before ssl is imported (gunicorn does this too
+# late). This is only necessary when `preload_app` is True. The gevent warning
+# is still printed, but testing shows that recursion errors do not occur (eg. on
+# use of `requests`) when monkey-patching here.
+# See also https://github.com/gevent/gevent/issues/1016 and
+# https://github.com/benoitc/gunicorn/issues/1566
+gevent.monkey.patch_all()
+
+
 _config = os.environ["ENVIRONMENT"]
 
 bind = "0.0.0.0:8000"


### PR DESCRIPTION
Testing shows that making HTTPS requests with `request` triggers the recursion error, but not when gevent's monkeypatching is done here.

However, the warning is still printed. I decided not to suppress it, as there may be packages other than requests that still have the potential to trigger the problem.