### PR TITLE
Fix docker-compose compatibility

### DIFF
--- a/{{cookiecutter.project_slug}}/docker-compose.yml
+++ b/{{cookiecutter.project_slug}}/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     environment:
       - ENVIRONMENT=${ENVIRONMENT:-development}
       - FLASK_APP=src/{{cookiecutter.project_module}}/wsgi.py
-      - SCRIPT_NAME=${SCRIPT_NAME:-}
+      - SCRIPT_NAME=${SCRIPT_NAME}
       - ALLOWED_ORIGINS=${ALLOWED_ORIGINS:-http://localhost:4200}
       - SENTRY_DSN=${SENTRY_DSN}
     command: gunicorn -c gunicorn.py {{cookiecutter.project_module}}.wsgi:app


### PR DESCRIPTION
Turns out the `${FOO:-}` syntax is not compatible with the docker-compose version used on travis, see f.ex. https://travis-ci.org/DD-DeCaF/warehouse/jobs/396489098#L549

I suggest avoiding the syntax as opposed to upgrading the docker-compose version in all builds, which adds to build time and the complexity of the travis configuration