### PR TITLE
Replace flask-restplus with flask-apispec

### DIFF
--- a/{{cookiecutter.project_slug}}/requirements.in
+++ b/{{cookiecutter.project_slug}}/requirements.in
@@ -1,4 +1,4 @@
 Flask
 Flask-Cors
-flask-restplus
+flask-apispec
 raven[flask]

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_module}}/app.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_module}}/app.py
@@ -18,22 +18,16 @@
 import logging
 import logging.config
 
-from flask import Flask
+from flask import Flask, jsonify
 from flask_cors import CORS
-from flask_restplus import Api
 from raven.contrib.flask import Sentry
 from werkzeug.contrib.fixers import ProxyFix
 
 
 app = Flask(__name__)
-api = Api(
-    title="{{cookiecutter.project_name}}",
-    version="0.1.0",
-    description="{{cookiecutter.project_short_description}}",
-)
 
 
-def init_app(application, interface):
+def init_app(application):
     """Initialize the main app with config information and routes."""
     from {{cookiecutter.project_module}}.settings import current_config
     application.config.from_object(current_config())
@@ -49,8 +43,7 @@ def init_app(application, interface):
 
     # Add routes and resources.
     from {{cookiecutter.project_module}} import resources
-    interface.add_resource(resources.HelloWorld, "/")
-    interface.init_app(application)
+    resources.init_app(application)
 
     # Add CORS information for all resources.
     CORS(application)

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_module}}/app.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_module}}/app.py
@@ -48,6 +48,14 @@ def init_app(application):
     # Add CORS information for all resources.
     CORS(application)
 
+    # Add an error handler for webargs parser error, ensuring a JSON response
+    # including all error messages produced from the parser.
+    @app.errorhandler(422)
+    def handle_webargs_error(error):
+        response = jsonify(error.data['messages'])
+        response.status_code = error.code
+        return response
+
     # Please keep in mind that it is a security issue to use such a middleware
     # in a non-proxy setup because it will blindly trust the incoming headers
     # which might be forged by malicious clients.

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_module}}/resources.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_module}}/resources.py
@@ -39,11 +39,8 @@ class HelloResource(MethodResource):
 def init_app(app):
     """Register API resources on the provided Flask application."""
     def register(path, resource):
-        app.add_url_rule(
-            path,
-            view_func=resource.as_view(resource.__class__.__name__),
-        )
-        docs.register(resource, endpoint=resource.__class__.__name__)
+        app.add_url_rule(path, view_func=resource.as_view(resource.__name__))
+        docs.register(resource, endpoint=resource.__name__)
 
     docs = FlaskApiSpec(app)
     register('/hello', HelloResource)

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_module}}/resources.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_module}}/resources.py
@@ -15,15 +15,35 @@
 
 """Implement RESTful API endpoints using resources."""
 
-from flask_restplus import Resource
+from flask_apispec import MethodResource, marshal_with, use_kwargs
+from flask_apispec.extension import FlaskApiSpec
 
-from {{cookiecutter.project_module}}.app import app
+from .schemas import HelloSchema
 
 
-class HelloWorld(Resource):
-    """Example resource."""
+class HelloResource(MethodResource):
+    """Example API resource."""
 
-    def get(self):
-        """Shout out loud."""
-        app.logger.debug("I ran!")
-        return "Hello World!"
+    @use_kwargs(HelloSchema)
+    @marshal_with(HelloSchema, code=200)
+    def get(self, name):
+        """
+        Implement example endpoint.
+
+        This demonstrates both how to use request argument validation
+        (use_kwargs) and response marshalling (marshal_with).
+        """
+        return {'name': name}
+
+
+def init_app(app):
+    """Register API resources on the provided Flask application."""
+    def register(path, resource):
+        app.add_url_rule(
+            path,
+            view_func=resource.as_view(resource.__class__.__name__),
+        )
+        docs.register(resource, endpoint=resource.__class__.__name__)
+
+    docs = FlaskApiSpec(app)
+    register('/hello', HelloResource)

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_module}}/schemas.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_module}}/schemas.py
@@ -13,9 +13,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Prepare the application for use by the WSGI server (gunicorn)."""
+"""Marshmallow schemas for marshalling the API endpoints."""
 
-from {{cookiecutter.project_module}}.app import app, init_app
+from marshmallow import Schema, fields
 
 
-init_app(app)
+class StrictSchema(Schema):
+    """Shared empty schema instance with strict validation."""
+
+    class Meta:
+        """Meta class for marshmallow schemas."""
+
+        strict = True
+
+
+class HelloSchema(StrictSchema):
+    """Example schema."""
+
+    name = fields.Str(required=True)

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_module}}/settings.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_module}}/settings.py
@@ -49,6 +49,8 @@ class Default:
         self.DEBUG = True
         self.SECRET_KEY = os.urandom(24)
         self.BUNDLE_ERRORS = True
+        self.APISPEC_TITLE = "{{cookiecutter.project_name}}"
+        self.APISPEC_SWAGGER_UI_URL = "/"
         self.CORS_ORIGINS = os.environ['ALLOWED_ORIGINS'].split(',')
         self.SENTRY_DSN = os.environ.get('SENTRY_DSN')
         self.SENTRY_CONFIG = {

--- a/{{cookiecutter.project_slug}}/tests/conftest.py
+++ b/{{cookiecutter.project_slug}}/tests/conftest.py
@@ -17,7 +17,6 @@
 
 import pytest
 
-from {{cookiecutter.project_module}}.app import api
 from {{cookiecutter.project_module}}.app import app as app_
 from {{cookiecutter.project_module}}.app import init_app
 
@@ -25,7 +24,7 @@ from {{cookiecutter.project_module}}.app import init_app
 @pytest.fixture(scope="session")
 def app():
     """Provide an initialized Flask for use in certain test cases."""
-    init_app(app_, api)
+    init_app(app_)
     return app_
 
 

--- a/{{cookiecutter.project_slug}}/tests/integration/test_endpoints.py
+++ b/{{cookiecutter.project_slug}}/tests/integration/test_endpoints.py
@@ -21,3 +21,10 @@ def test_docs(client):
     resp = client.get("/")
     assert resp.status_code == 200
     assert resp.content_type == "text/html; charset=utf-8"
+
+
+def test_hello(client):
+    """Expect the example endpoint to echo provided name."""
+    resp = client.get("/hello", json={'name': "Cleese"})
+    assert resp.status_code == 200
+    assert resp.json == {'name': "Cleese"}


### PR DESCRIPTION
As previously discussed, flask-restplus appears to have become a somewhat bloated fork of flask-restful. It seems to have taken flask-restful, added swagger api support, reinvented the [flask error handling wheel](https://flask-restplus.readthedocs.io/en/stable/errors.html), and proceeded to become its own monolithic one-size-fits-all REST API lib.

Flask-restful, despite appearing somewhat more streamlined, also has the issue of [deprecating its entire request parser](https://flask-restful.readthedocs.io/en/latest/reqparse.html) in favor of marshmallow. In addition, our original reason to prefer flask-restplus was the swagger api support.

So, I wanted to replace the whole stack with smaller "do one thing and do it well" libraries, namely webargs, marshmallow and apispec. However, the latter would require [explicit docstring documentation](https://apispec.readthedocs.io/en/stable/using_plugins.html#example-flask-and-marshmallow-plugins), which is inconvenient and redundant.

I then found [flask-apispec](https://github.com/jmcarp/flask-apispec) which has the following benefits:

* Seamlessly integrates webargs, marshmallow and apispec
* Automatically generates swagger API from declared resources
* Implements response marshalling (which you wouldn't get from webargs or marshmallow alone)
* Explicitly states that it attempts to provide similar functionality to flask-rest{ful,plus}, but with greater flexibility and less code

Although our resource implementations still look more or less the same, I feel that this change brings us closer to the lightweight webservice ideal, and I am more comfortable getting invested in these libraries. Although, it is admittedly hard to quantify that gut feeling.