### PR TITLE
Add error handlers

### DIFF
--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_module}}/app.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_module}}/app.py
@@ -18,10 +18,12 @@
 import logging
 import logging.config
 
-from flask import Flask, jsonify
+from flask import Flask
 from flask_cors import CORS
 from raven.contrib.flask import Sentry
 from werkzeug.contrib.fixers import ProxyFix
+
+from . import errorhandlers
 
 
 app = Flask(__name__)
@@ -48,13 +50,8 @@ def init_app(application):
     # Add CORS information for all resources.
     CORS(application)
 
-    # Add an error handler for webargs parser error, ensuring a JSON response
-    # including all error messages produced from the parser.
-    @app.errorhandler(422)
-    def handle_webargs_error(error):
-        response = jsonify(error.data['messages'])
-        response.status_code = error.code
-        return response
+    # Register error handlers
+    errorhandlers.init_app(application)
 
     # Please keep in mind that it is a security issue to use such a middleware
     # in a non-proxy setup because it will blindly trust the incoming headers

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_module}}/errorhandlers.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_module}}/errorhandlers.py
@@ -60,7 +60,7 @@ def init_app(app):
         return response
 
     @app.errorhandler(Exception)
-    def handle_http_error(error):
+    def handle_uncaught_error(error):
         """
         Handle any uncaught exceptions.
 

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_module}}/errorhandlers.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_module}}/errorhandlers.py
@@ -33,51 +33,55 @@ logger = logging.getLogger(__name__)
 
 
 def init_app(app):
-    @app.errorhandler(422)
-    def handle_webargs_error(error):
-        """
-        Handle webargs parser errors.
+    app.register_error_handler(422, handle_webargs_error)
+    app.register_error_handler(HTTPException, handle_http_error)
+    app.register_error_handler(Exception, handle_uncaught_error)
 
-        Ensures a JSON response including all error messages produced from the
-        parser, that we know to be available on the error object.
 
-        Note that this sets some constrains for manually throwing 422 exceptions
-        as error messages must be made available in the same way.
-        """
-        response = jsonify(error.data['messages'])
+def handle_webargs_error(error):
+    """
+    Handle webargs parser errors.
+
+    Ensures a JSON response including all error messages produced from the
+    parser, that we know to be available on the error object.
+
+    Note that this sets some constrains for manually throwing 422 exceptions
+    as error messages must be made available in the same way.
+    """
+    response = jsonify(error.data['messages'])
+    response.status_code = error.code
+    return response
+
+
+def handle_http_error(error):
+    """
+    Handle HTTPExceptions.
+
+    Include the error description and corresponding status code, known to be
+    available on the werkzeug HTTPExceptions.
+    """
+    # As werkzeug's routing exceptions also inherit from HTTPException,
+    # check for those and allow them to return with redirect responses.
+    if isinstance(error, RoutingException):
+        return error
+    else:
+        response = jsonify({'message': error.description})
         response.status_code = error.code
         return response
 
-    @app.errorhandler(HTTPException)
-    def handle_http_error(error):
-        """
-        Handle HTTPExceptions.
 
-        Include the error description and corresponding status code, known to be
-        available on the werkzeug HTTPExceptions.
-        """
-        # As werkzeug's routing exceptions also inherit from HTTPException,
-        # check for those and allow them to return with redirect responses.
-        if isinstance(error, RoutingException):
-            return error
-        else:
-            response = jsonify({'message': error.description})
-            response.status_code = error.code
-            return response
+def handle_uncaught_error(error):
+    """
+    Handle any uncaught exceptions.
 
-    @app.errorhandler(Exception)
-    def handle_uncaught_error(error):
-        """
-        Handle any uncaught exceptions.
+    Since the handler suppresses the actual exception, log it explicitly to
+    ensure it's logged and recorded in Sentry.
 
-        Since the handler suppresses the actual exception, log it explicitly to
-        ensure it's logged and recorded in Sentry.
-
-        Including the exception message would be helpful, but we would risk
-        leaking sensitive information, so return a generic error message to the
-        client.
-        """
-        logger.error("Uncaught exception", exc_info=sys.exc_info())
-        response = jsonify({'message': "Internal server error"})
-        response.status_code = 500
-        return response
+    Including the exception message would be helpful, but we would risk
+    leaking sensitive information, so return a generic error message to the
+    client.
+    """
+    logger.error("Uncaught exception", exc_info=sys.exc_info())
+    response = jsonify({'message': "Internal server error"})
+    response.status_code = 500
+    return response

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_module}}/errorhandlers.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_module}}/errorhandlers.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2018, Novo Nordisk Foundation Center for Biosustainability,
+# Technical University of Denmark.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Error handlers and custom exceptions.
+
+http://flask.pocoo.org/docs/1.0/errorhandling/
+http://flask.pocoo.org/docs/1.0/patterns/apierrors/
+"""
+
+import logging
+import sys
+
+from flask import jsonify
+
+from werkzeug.exceptions import HTTPException
+
+
+logger = logging.getLogger(__name__)
+
+
+def init_app(app):
+    @app.errorhandler(422)
+    def handle_webargs_error(error):
+        """
+        Handle webargs parser errors.
+
+        Ensures a JSON response including all error messages produced from the
+        parser, that we know to be available on the error object.
+
+        Note that this sets some constrains for manually throwing 422 exceptions
+        as error messages must be made available in the same way.
+        """
+        response = jsonify(error.data['messages'])
+        response.status_code = error.code
+        return response
+
+    @app.errorhandler(HTTPException)
+    def handle_http_error(error):
+        """
+        Handle HTTPExceptions.
+
+        Include the error description and corresponding status code, known to be
+        available on the werkzeug HTTPExceptions.
+        """
+        response = jsonify({'message': error.description})
+        response.status_code = error.code
+        return response
+
+    @app.errorhandler(Exception)
+    def handle_http_error(error):
+        """
+        Handle any uncaught exceptions.
+
+        Since the handler suppresses the actual exception, log it explicitly to
+        ensure it's logged and recorded in Sentry.
+
+        Including the exception message would be helpful, but we would risk
+        leaking sensitive information, so return a generic error message to the
+        client.
+        """
+        logger.error("Uncaught exception", exc_info=sys.exc_info())
+        response = jsonify({'message': "Internal server error"})
+        response.status_code = 500
+        return response


### PR DESCRIPTION
Handles the following cases:

- Webargs parser errors (422) includes all validation messages
- HTTPExceptions (typically raised through `flask.abort` or by raising any werkzeug http exception includes the description and returns the appropriate code
- Any other uncaught exception will log the error and return a generic error message.

Note that the third handler is necessary, because flask converts uncaught exceptions into the `InternalServerError` exception which in turn is then handled by the `HTTPException` error handler, but it passes the original exception which is unlikely to have the `description` and `code` attributes, resulting in an error in the actual handler ([like this](https://sentry.io/technical-university-of-denmark/model-storage-staging/issues/780475434/)). Handling uncaught exceptions explicitly solves this.

It's also possible to extend services with custom exceptions that are handled here when appropriate, according to the pattern documented here: http://flask.pocoo.org/docs/1.0/patterns/apierrors/