### PR TITLE
Add readiness endpoint and probes

### DIFF
--- a/{{cookiecutter.project_slug}}/deployment/deployment.yml
+++ b/{{cookiecutter.project_slug}}/deployment/deployment.yml
@@ -35,6 +35,11 @@ spec:
               name: {{cookiecutter.project_slug}}-production
               key: SENTRY_DSN
         command: ["gunicorn", "-c", "gunicorn.py", "{{cookiecutter.project_module}}.wsgi:app"]
+        readinessProbe:
+          httpGet:
+            path: /{{cookiecutter.project_slug}}/healthz
+            port: 8000
+          initialDelaySeconds: 5
         resources:
           requests:
             cpu: "10m"
@@ -80,6 +85,11 @@ spec:
               name: {{cookiecutter.project_slug}}-staging
               key: SENTRY_DSN
         command: ["gunicorn", "-c", "gunicorn.py", "{{cookiecutter.project_module}}.wsgi:app"]
+        readinessProbe:
+          httpGet:
+            path: /{{cookiecutter.project_slug}}/healthz
+            port: 8000
+          initialDelaySeconds: 5
         resources:
           requests:
             cpu: "5m"

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_module}}/resources.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_module}}/resources.py
@@ -28,7 +28,19 @@ def init_app(app):
         docs.register(resource, endpoint=resource.__name__)
 
     docs = FlaskApiSpec(app)
+    app.add_url_rule('/healthz', healthz.__name__, healthz)
     register('/hello', HelloResource)
+
+
+def healthz():
+    """
+    Return an empty, successful response for readiness checks.
+
+    A successful response signals that the app is initialized and ready to
+    receive traffic. The main use case is for apps with slow initialization, but
+    external dependencies like database connections can also be tested here.
+    """
+    return ""
 
 
 class HelloResource(MethodResource):

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_module}}/resources.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_module}}/resources.py
@@ -21,6 +21,16 @@ from flask_apispec.extension import FlaskApiSpec
 from .schemas import HelloSchema
 
 
+def init_app(app):
+    """Register API resources on the provided Flask application."""
+    def register(path, resource):
+        app.add_url_rule(path, view_func=resource.as_view(resource.__name__))
+        docs.register(resource, endpoint=resource.__name__)
+
+    docs = FlaskApiSpec(app)
+    register('/hello', HelloResource)
+
+
 class HelloResource(MethodResource):
     """Example API resource."""
 
@@ -34,13 +44,3 @@ class HelloResource(MethodResource):
         (use_kwargs) and response marshalling (marshal_with).
         """
         return {'name': name}
-
-
-def init_app(app):
-    """Register API resources on the provided Flask application."""
-    def register(path, resource):
-        app.add_url_rule(path, view_func=resource.as_view(resource.__name__))
-        docs.register(resource, endpoint=resource.__name__)
-
-    docs = FlaskApiSpec(app)
-    register('/hello', HelloResource)


### PR DESCRIPTION
We've already started using this in a few services, so I think it makes sense to add it as a default to the cookiecutter.