### PR TITLE
Move travis test logic out of makefile

### DIFF
--- a/{{cookiecutter.project_slug}}/.travis.yml
+++ b/{{cookiecutter.project_slug}}/.travis.yml
@@ -27,6 +27,10 @@ script:
   - make license
   - make safety
   - make test-travis
+  - # Run the tests and report coverage (see https://docs.codecov.io/docs/testing-with-docker).
+  - mkdir --parents /tmp/coverage
+  - docker-compose run --rm -e ENVIRONMENT=testing -v "/tmp/coverage:/tmp/coverage" web pytest --cov-report "xml:/tmp/coverage/coverage.xml" --cov-report term --cov=src/{{cookiecutter.project_module}}
+  - bash <(curl -s https://codecov.io/bash) -f "/tmp/coverage/coverage.xml"
 
 before_deploy:
   - ./scripts/install_gcloud.sh

--- a/{{cookiecutter.project_slug}}/.travis.yml
+++ b/{{cookiecutter.project_slug}}/.travis.yml
@@ -26,7 +26,6 @@ script:
   - make isort
   - make license
   - make safety
-  - make test-travis
   - # Run the tests and report coverage (see https://docs.codecov.io/docs/testing-with-docker).
   - mkdir --parents /tmp/coverage
   - docker-compose run --rm -e ENVIRONMENT=testing -v "/tmp/coverage:/tmp/coverage" web pytest --cov-report "xml:/tmp/coverage/coverage.xml" --cov-report term --cov=src/{{cookiecutter.project_module}}

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -56,15 +56,6 @@ test:
 	docker-compose run --rm -e ENVIRONMENT=testing web \
 		pytest --cov=src/{{cookiecutter.project_module}}
 
-## Run the tests and report coverage (see https://docs.codecov.io/docs/testing-with-docker).
-shared := /tmp/coverage
-test-travis:
-	mkdir --parents "$(shared)"
-	docker-compose run --rm -e ENVIRONMENT=testing -v "$(shared):$(shared)" \
-		web pytest --cov-report "xml:$(shared)/coverage.xml" --cov-report term \
-		--cov=src/{{cookiecutter.project_module}}
-	bash <(curl -s https://codecov.io/bash) -f "$(shared)/coverage.xml"
-
 ## Stop all services.
 stop:
 	docker-compose stop


### PR DESCRIPTION
The makefile is generally considered a helper for often-used workflow
commands so it doesn't make sense to me to keep the travis test logic
there. Travis may use other makefile targets that are in common, but I
think it makes sense to spell out the test command (and codecov logic)
in .travis.yml.