### PR TITLE
Ignore D100-D107 by default

### DIFF
--- a/{{cookiecutter.project_slug}}/setup.cfg
+++ b/{{cookiecutter.project_slug}}/setup.cfg
@@ -31,6 +31,7 @@ universal = 1
 universal = 1
 
 [flake8]
+ignore = D100,D101,D102,D103,D104,D105,D106,D107
 max-line-length = 80
 exclude =
     __init__.py


### PR DESCRIPTION
Those codes[1] require all public elements to always include a
docstring. That might make sense for libraries, but I consider it too
strict for our applications. Rather than having a strict rule, it is up
to developers and reviewers to judge in what cases a docstring is
necessary.

As soon as a docstring is in place, all the formatting rules still apply
of course, as long as they are not in conflict with higher-priority
formatters (potentially black) or the numpy guide.

[1] http://www.pydocstyle.org/en/2.1.1/error_codes.html