### PR TITLE
Update proxyfix import

### DIFF
--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_module}}/app.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_module}}/app.py
@@ -21,7 +21,7 @@ import logging.config
 from flask import Flask
 from flask_cors import CORS
 from raven.contrib.flask import Sentry
-from werkzeug.contrib.fixers import ProxyFix
+from werkzeug.middleware.proxy_fix import ProxyFix
 
 
 app = Flask(__name__)


### PR DESCRIPTION
DeprecationWarning: 'werkzeug.contrib.fixers.ProxyFix' has moved to 'werkzeug.middleware.proxy_fix.ProxyFix'. This import is deprecated as of version 0.15 and will be removed in 1.0.