### PR TITLE
Run service QA suite on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,17 @@ language: python
 python: "3.6"
 git:
   depth: 2
+services:
+  - docker
 branches:
   - master
 before_install:
   - pip install -U pip setuptools wheel
 install:
   - pip install cookiecutter flake8 pytest pytest-cookies
-script: pytest
+script:
+  - pytest
+  - ./.travis/test-service.sh
 notifications:
   on_success: never
   on_failure: always

--- a/.travis/test-service.sh
+++ b/.travis/test-service.sh
@@ -1,0 +1,8 @@
+set -eux
+cookiecutter --no-input .
+pushd name-of-the-project
+make pip-compile
+# The generated requirements file is initially owned by root, so update ownership.
+sudo chown -R travis .
+make network build qa
+popd


### PR DESCRIPTION
Going beyond simply baking the project and running flake8 from the travis environment; this ensures that any service generated by the cookiecutter always passes the full QA suite.
