### PR TITLE
Test gunicorn

### DIFF
--- a/.travis/test-service.sh
+++ b/.travis/test-service.sh
@@ -1,4 +1,11 @@
 set -eux
+
+# Test the current state of the cookiecutter app and its configuration by
+# creating a temporary service from the template and running the full QA suite
+# in it. Note that the image builds on a wsgi-base image that has already
+# passed QA, so we're not testing the dependencies here - just the code and
+# configuration in the cookiecutter.
+
 cookiecutter --no-input .
 pushd name-of-the-project
 make pip-compile

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -65,14 +65,14 @@ license:
 safety:
 	docker-compose run --rm web safety check
 
-## Check the gunicorn configuration.
-gunicorn:
-	docker-compose run --rm web gunicorn --check-config -c gunicorn.py {{cookiecutter.project_module}}.wsgi:app
-
 ## Run the tests.
 test:
 	docker-compose run --rm -e ENVIRONMENT=testing web \
 		pytest --cov=src/{{cookiecutter.project_module}}
+
+## Check the gunicorn configuration.
+gunicorn:
+	docker-compose run --rm web gunicorn --check-config -c gunicorn.py {{cookiecutter.project_module}}.wsgi:app
 
 ## Stop all services.
 stop:

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -29,7 +29,7 @@ start:
 	docker-compose up --force-recreate -d
 
 ## Run all QA targets.
-qa: style safety test
+qa: style safety test gunicorn
 
 ## Run all style related targets.
 style: black-check flake8 isort-check license
@@ -64,6 +64,10 @@ license:
 ## Check for known vulnerabilities in python dependencies.
 safety:
 	docker-compose run --rm web safety check
+
+## Check the gunicorn configuration.
+gunicorn:
+	docker-compose run --rm web gunicorn --check-config -c gunicorn.py {{cookiecutter.project_module}}.wsgi:app
 
 ## Run the tests.
 test:


### PR DESCRIPTION
Since the python test suite never executes gunicorn, potential problems with the installation aren't currently caught by the QA suite.

This addition covers both verifying that the gunicorn installation works, and even checking the gunicorn configuration using the built-in checker.

Such a check would have caught [this issue](https://github.com/DD-DeCaF/wsgi-base/pull/9) and caused the wsgi-base image daily build to fail, ensuring that services continue to use a functioning version of gunicorn until we'd dealt with the issue.