### PR TITLE
Install build tools temporarily during pip-sync

### DIFF
--- a/{{cookiecutter.project_slug}}/Dockerfile
+++ b/{{cookiecutter.project_slug}}/Dockerfile
@@ -30,7 +30,9 @@ WORKDIR "${CWD}"
 
 COPY requirements ./requirements
 
-RUN pip-sync requirements/requirements.txt
+RUN apk add --no-cache build-base && \
+    pip-sync requirements/requirements.txt && \
+    apk del build-base
 
 COPY . "${CWD}/"
 


### PR DESCRIPTION
This changes the image build in order to build certain python dependencies from source. We already do that in the [base image](https://github.com/DD-DeCaF/wsgi-base/blob/master/alpine/Dockerfile#L28), but if some dependency is upgraded in the base, then the older version will be reinstalled in the service. If that installation requires a source build, it will fail unless build tools are available. Although we should upgrade service dependencies to match the base often, I think it's pragmatic to enable source builds to avoid blockers like this when working on unrelated features.